### PR TITLE
로그인 회원가입 통신

### DIFF
--- a/src/components/ButtonComponent.tsx
+++ b/src/components/ButtonComponent.tsx
@@ -1,22 +1,46 @@
 import React, { ReactElement } from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 type ButtonFunctionalComponent = {
-  (props: { children: string }): ReactElement;
+  (props: {
+    children: string;
+    clickHandler: React.MouseEventHandler<HTMLButtonElement>;
+    disabled: boolean;
+  }): ReactElement;
 };
 
-const ButtonComponent: ButtonFunctionalComponent = ({ children }) => {
-  return <BasicButton disabled>{children}</BasicButton>;
+const ButtonComponent: ButtonFunctionalComponent = ({
+  children,
+  clickHandler,
+  disabled,
+}) => {
+  return (
+    <BasicButton onClick={clickHandler} disabled={disabled}>
+      {children}
+    </BasicButton>
+  );
 };
 
 export default ButtonComponent;
 
-const BasicButton = styled.button`
+const BasicButton = styled.button<{ disabled: boolean }>`
   width: 100%;
   height: 3rem;
-  background-color: dodgerblue;
-  color: blue;
   border: none;
   border-radius: 10px;
   font-size: 1.5rem;
+  ${({ disabled }) => {
+    if (disabled) {
+      return css`
+        background-color: grey;
+        color: white;
+      `;
+    } else {
+      return css`
+        background-color: dodgerblue;
+        color: black;
+        cursor: pointer;
+      `;
+    }
+  }}
 `;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-const BASE_URL = `https://5co7shqbsf.execute-api.ap-northeast-2.amazonaws.com/production/`;
+const BASE_URL = `https://5co7shqbsf.execute-api.ap-northeast-2.amazonaws.com/production`;
 
 export const configURL = {
   signIn: `${BASE_URL}/auth/signin`,

--- a/src/pages/Auth/AuthLayout.tsx
+++ b/src/pages/Auth/AuthLayout.tsx
@@ -1,21 +1,38 @@
-import React, { useState } from "react";
-import styled from "styled-components";
+import React, { useEffect, useState } from "react";
+import styled, { css } from "styled-components";
 import AuthForm from "./AuthForm";
 import { Navigate } from "react-router-dom";
 
 const AuthLayout = () => {
   const [isSignIn, setIsSignIn] = useState<boolean>(true);
+  const [errorMessage, setErrorMessage] = useState<string>(``);
+
+  useEffect(() => {
+    !!errorMessage === true &&
+      setTimeout(() => {
+        setErrorMessage("");
+      }, 4000);
+  }, [errorMessage]);
 
   return (
     <>
       {localStorage.getItem("token") && <Navigate to={"/todo"} replace />}
       <FormWrapper>
+        <ErrorMassage isError={!!errorMessage}>{errorMessage}</ErrorMassage>
         {isSignIn ? (
-          <AuthForm isSignIn={isSignIn} setIsSignIn={setIsSignIn}>
+          <AuthForm
+            isSignIn={isSignIn}
+            setIsSignIn={setIsSignIn}
+            setErrorMessage={setErrorMessage}
+          >
             로그인
           </AuthForm>
         ) : (
-          <AuthForm isSignIn={isSignIn} setIsSignIn={setIsSignIn}>
+          <AuthForm
+            isSignIn={isSignIn}
+            setIsSignIn={setIsSignIn}
+            setErrorMessage={setErrorMessage}
+          >
             회원가입
           </AuthForm>
         )}
@@ -35,4 +52,27 @@ const FormWrapper = styled.form`
   padding: 0 30px;
   border: 2px solid rgb(200, 200, 200);
   border-radius: 20px;
+`;
+
+const ErrorMassage = styled.p<{ isError: boolean }>`
+  position: absolute;
+  bottom: 100%;
+  right: 0;
+  ${({ isError }) => {
+    if (isError) {
+      return css`
+        transform: translateY(40px);
+      `;
+    } else {
+      return css``;
+    }
+  }}
+  width: 500px;
+  height: 40px;
+  padding-left: 30px;
+  font-size: 1.5rem;
+  line-height: 40px;
+  background-color: red;
+  color: white;
+  transition: all 0.3s ease;
 `;

--- a/src/pages/Todo/TodoList.tsx
+++ b/src/pages/Todo/TodoList.tsx
@@ -4,8 +4,11 @@ import { Navigate } from "react-router-dom";
 const TodoList = () => {
   return (
     <>
-      {localStorage.getItem("token") ?? <Navigate to={"/"} replace />}
-      <div>todo리스트</div>
+      {localStorage.getItem("token") ? (
+        <div>todo리스트</div>
+      ) : (
+        <Navigate to={"/"} replace />
+      )}
     </>
   );
 };

--- a/src/utils/FetchApi.ts
+++ b/src/utils/FetchApi.ts
@@ -1,0 +1,49 @@
+export const FetchApi = {
+  get: async (url: string, requestHeaders: HeadersInit): Promise<Response> => {
+    const result = await fetch(url, { headers: requestHeaders });
+    return result;
+  },
+  post: async <T>(
+    url: string,
+    parameter: T,
+    requestHeaders: HeadersInit
+  ): Promise<Response> => {
+    const result = fetch(url, {
+      method: "POST",
+      headers: requestHeaders,
+      body: JSON.stringify(parameter),
+    });
+    return result;
+  },
+  delete: async (
+    url: string,
+    requestHeaders: HeadersInit
+  ): Promise<Response> => {
+    const result = fetch(url, { method: "DELETE", headers: requestHeaders });
+    return result;
+  },
+  put: async <T>(
+    url: string,
+    parameter: T,
+    requestHeaders: HeadersInit
+  ): Promise<Response> => {
+    const result = fetch(url, {
+      method: "PUT",
+      headers: requestHeaders,
+      body: JSON.stringify(parameter),
+    });
+    return result;
+  },
+  create: async <T>(
+    url: string,
+    parameter: T,
+    requestHeaders: HeadersInit
+  ): Promise<Response> => {
+    const result = fetch(url, {
+      method: "",
+      headers: requestHeaders,
+      body: JSON.stringify(parameter),
+    });
+    return result;
+  },
+};

--- a/src/utils/RequestHeaders.ts
+++ b/src/utils/RequestHeaders.ts
@@ -1,0 +1,3 @@
+export const requestHeaders: HeadersInit = new Headers();
+requestHeaders.set("Content-Type", "application/json");
+requestHeaders.set("Authorization", localStorage.getItem("token") || "");


### PR DESCRIPTION
로그인 및 회원가입 API 적용 완료,

fetch에 필요한 url은 config에서 객체로 관리(signin, signup, todo)/

fetch api 는 get, create, post, put, delete 로 각각 객체의 함수로 저장하여, import 해와서 사용하는 방식으로 utils에 따로 관리하였습니다.

headers도 typescript를 적용하여 import 해오는 방식으로 구현하였습니다.

로컬스토리지에 토큰의 여부에 따라 signin,signup 페이지에서 바로 todo 페이지로 리다이렉트 시키거나, todo페이지에서 signin,signup페이지로 바로 리다이렉트 하도록 하였습니다.

통신의 결과에 따라 statu200번대 (response.ok 가 true)일 경우에는 토큰 저장 및 페이지 이동이 되도록,

통신이 실패한경우(response.ok가 false)에는 에러메세지를 띄워서 실패의 이유를 알려주도록 하였습니다.